### PR TITLE
Add Firestore rules and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Firestore Security Rules
+
+Deploy the rules using:
+
+```sh
+firebase deploy --only firestore:rules
+```
+
+You can test the rules locally with the Firebase Emulator Suite:
+
+```sh
+firebase emulators:start --only firestore
+```

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,27 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isOwner(uid) {
+      return request.auth != null && request.auth.uid == uid;
+    }
+
+    function isValid(data, uid) {
+      return data.keys().hasAll(['uid', 'sharing']) &&
+             data.uid == uid &&
+             data.uid == request.auth.uid &&
+             data.sharing is bool;
+    }
+
+    match /locations/{uid} {
+      // Allow owner to read their document or anyone to read shared documents
+      allow get: if isOwner(uid) || resource.data.sharing == true;
+      // Allow queries only when filtering for shared locations
+      allow list: if request.query.where('sharing', '==', true);
+      // Allow owner to create or update their document with valid fields
+      allow create, update: if isOwner(uid) && isValid(request.resource.data, uid);
+      // Allow owner to delete their document
+      allow delete: if isOwner(uid);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules restricting access to user documents and validating `uid` and `sharing`
- document deployment and emulator testing steps for rules

## Testing
- `npm test -- --watchAll=false` (fails: Jest encountered an unexpected token)

------
https://chatgpt.com/codex/tasks/task_e_68ad4a8615a48328a31adedabb47fdcb