### PR TITLE
Add component tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --watch=false

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/LoginForm.test.jsx
+++ b/src/components/LoginForm.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import LoginForm from './LoginForm';
+
+jest.mock('../firebase', () => ({ auth: {} }));
+jest.mock('firebase/auth', () => ({
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+test('renders login form fields', () => {
+  render(<LoginForm />);
+  expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
+});

--- a/src/components/MapComponent.jsx
+++ b/src/components/MapComponent.jsx
@@ -15,9 +15,9 @@ import {
   serverTimestamp,
 } from "firebase/firestore";
 
-const MapComponent = ({ currentUser, shareLocation }) => {
-  const [users, setUsers] = useState([]);
-  const [position, setPosition] = useState(null);
+const MapComponent = ({ currentUser, shareLocation, mockUsers = null, mockPosition = null }) => {
+  const [users, setUsers] = useState(mockUsers || []);
+  const [position, setPosition] = useState(mockPosition);
 
   // Custom marker icon
   const icon = new L.Icon({
@@ -28,11 +28,12 @@ const MapComponent = ({ currentUser, shareLocation }) => {
   });
 
   // Get user's current position and optionally update Firestore
-  useEffect(() => {
-    if (!navigator.geolocation) {
-      console.error("Geolocation is not supported.");
-      return;
-    }
+    useEffect(() => {
+      if (mockPosition) return;
+      if (!navigator.geolocation) {
+        console.error("Geolocation is not supported.");
+        return;
+      }
 
     const watchId = navigator.geolocation.watchPosition(
       async (pos) => {
@@ -55,15 +56,16 @@ const MapComponent = ({ currentUser, shareLocation }) => {
   }, [shareLocation, currentUser]);
 
   // Listen to shared users' locations
-  useEffect(() => {
-    const q = query(collection(db, "users"), where("shareLocation", "==", true));
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const usersList = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-      setUsers(usersList);
-    });
+    useEffect(() => {
+      if (mockUsers) return;
+      const q = query(collection(db, "users"), where("shareLocation", "==", true));
+      const unsubscribe = onSnapshot(q, (snapshot) => {
+        const usersList = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        setUsers(usersList);
+      });
 
-    return () => unsubscribe();
-  }, []);
+      return () => unsubscribe();
+    }, [mockUsers]);
 
   return (
     <div style={{ height: "90vh", width: "100%" }}>

--- a/src/components/MapComponent.test.jsx
+++ b/src/components/MapComponent.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../firebase', () => ({ db: {} }));
+
+jest.mock('leaflet', () => ({
+  Icon: function() {
+    return null;
+  }
+}));
+
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div>{children}</div>,
+  TileLayer: () => <div />,
+  Marker: ({ children }) => <div data-testid="marker">{children}</div>,
+  Popup: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  doc: jest.fn(),
+  updateDoc: jest.fn(),
+  onSnapshot: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  serverTimestamp: jest.fn(),
+}));
+
+import MapComponent from './MapComponent';
+
+test('displays current and other user markers', () => {
+  const mockUsers = [
+    { id: 'user2', uid: 'user2', lat: 10, lng: 20, email: 'user2@example.com' }
+  ];
+  render(
+    <MapComponent
+      currentUser={{ uid: 'user1' }}
+      shareLocation={false}
+      mockPosition={[40, -74]}
+      mockUsers={mockUsers}
+    />
+  );
+
+  expect(screen.getAllByTestId('marker')).toHaveLength(2);
+  expect(screen.getByText('You are here')).toBeInTheDocument();
+  expect(screen.getByText('user2@example.com')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- replace placeholder CRA test with LoginForm test verifying login fields
- add MapComponent test using mock data and extend component with mock props
- run tests in CI via GitHub Actions

## Testing
- `CI=true npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68ad4a6d6bf08328be613078306170b9