### PR TITLE
Integrate login form and add component tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,15 @@
-import React, { useState } from "react";
+import React from "react";
 import useAuth from "./hooks/useAuth";
+import LoginForm from "./components/LoginForm";
 import MapComponent from "./components/MapComponent";
 
 function App() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const { user, login, register, logout } = useAuth();
 
   return (
     <div>
       {!user ? (
-        <div>
-          <h2>Register</h2>
-          <input placeholder="Email" onChange={(e) => setEmail(e.target.value)} />
-          <input
-            type="password"
-            placeholder="Password"
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <button onClick={() => register(email, password)}>Register</button>
-          <span>
-            {" "}Already have an account?
-            <button onClick={() => login(email, password)}>Login</button>
-          </span>
-        </div>
+        <LoginForm onLogin={login} onRegister={register} />
       ) : (
         <div>
           <h2>Welcome, {user.email}</h2>

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,11 +1,6 @@
 import React, { useState } from "react";
-import { auth } from "../firebase";
-import {
-  createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
-} from "firebase/auth";
 
-function LoginForm() {
+function LoginForm({ onLogin, onRegister }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isRegistering, setIsRegistering] = useState(false);
@@ -38,10 +33,10 @@ function LoginForm() {
     setLoading(true);
     try {
       if (isRegistering) {
-        await createUserWithEmailAndPassword(auth, email, password);
+        await onRegister(email, password);
         setSuccessMessage("✅ Registration successful!");
       } else {
-        await signInWithEmailAndPassword(auth, email, password);
+        await onLogin(email, password);
         setSuccessMessage("✅ Login successful!");
       }
     } catch (error) {

--- a/src/components/LoginForm.test.jsx
+++ b/src/components/LoginForm.test.jsx
@@ -1,8 +1,8 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import LoginForm from "./LoginForm";
 
-jest.mock('firebase/auth', () => ({
-  createUserWithEmailAndPassword: jest.fn(),
-  signInWithEmailAndPassword: jest.fn(),
-}));
-
-
+test("renders login form", () => {
+  render(<LoginForm onLogin={jest.fn()} onRegister={jest.fn()} />);
 });
+

--- a/src/components/MapComponent.jsx
+++ b/src/components/MapComponent.jsx
@@ -2,27 +2,41 @@ import React from "react";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import useGeolocation from "../hooks/useGeolocation";
 
+const icon = new L.Icon({
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+});
 
-  const icon = new L.Icon({
-    iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-  });
+export default function MapComponent({ currentUser }) {
+  const { position, markers, shareLocation, stopSharing } =
+    useGeolocation(currentUser);
 
-
+  return (
+    <div style={{ height: "90vh", width: "100%" }}>
+      <button onClick={shareLocation}>Share Location</button>
+      <button onClick={stopSharing}>Stop Sharing</button>
+      <MapContainer
+        center={position ? [position.lat, position.lng] : [0, 0]}
+        zoom={13}
+        scrollWheelZoom
+        style={{ height: "100%" }}
+      >
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution="&copy; OpenStreetMap contributors"
         />
-
-
+        {position && (
+          <Marker position={[position.lat, position.lng]} icon={icon}>
             <Popup>You are here</Popup>
           </Marker>
         )}
-
-
+        {markers
+          .filter((m) => m.uid !== currentUser.uid)
+          .map((m) => (
             <Marker key={m.uid} position={[m.lat, m.lng]} icon={icon}>
               <Popup>{m.email || "User"}</Popup>
             </Marker>
@@ -30,7 +44,4 @@ import "leaflet/dist/leaflet.css";
       </MapContainer>
     </div>
   );
-};
-
-export default MapComponent;
-
+}

--- a/src/components/MapComponent.test.jsx
+++ b/src/components/MapComponent.test.jsx
@@ -1,1 +1,25 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+jest.mock("react-leaflet", () => ({
+  MapContainer: ({ children }) => <div>{children}</div>,
+  TileLayer: () => <div />,
+  Marker: ({ children }) => <div>{children}</div>,
+  Popup: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("../hooks/useGeolocation", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    position: null,
+    markers: [],
+    shareLocation: jest.fn(),
+    stopSharing: jest.fn(),
+  })),
+}));
+
+test("renders map component", () => {
+  const MapComponent = require("./MapComponent").default;
+  render(<MapComponent currentUser={{ uid: "1" }} />);
+});
 


### PR DESCRIPTION
## Summary
- display a dedicated `LoginForm` when no user is authenticated
- hook the form into auth helpers and clean up the app component
- add basic rendering tests for login and map components

## Testing
- `npm test`
- `BROWSER=none npm start`

------
https://chatgpt.com/codex/tasks/task_e_68ad5086692883288157d42a7ce71a9c