### PR TITLE
Fix path separators in DataConnect example connector

### DIFF
--- a/dataconnect/example/connector.yaml
+++ b/dataconnect/example/connector.yaml
@@ -1,7 +1,7 @@
 connectorId: example
 generate:
   javascriptSdk:
-    outputDir: ..\..\dataconnect-generated\js\example-connector
+    outputDir: ../../dataconnect-generated/js/example-connector
     package: "@dataconnect/generated"
-    packageJsonDir: ..\..
+    packageJsonDir: ../../
     react: true


### PR DESCRIPTION
## Summary
- use POSIX-style paths in DataConnect example connector configuration

## Testing
- `npm test`
- `npx @firebase/dataconnect-cli generate dataconnect/dataconnect.yaml` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@firebase%2fdataconnect-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7d45f9148328a53b3322894a5c46