### PR TITLE
Add comprehensive LoginForm and MapComponent tests

### DIFF
--- a/src/components/LoginForm.test.jsx
+++ b/src/components/LoginForm.test.jsx
@@ -1,8 +1,54 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import LoginForm from "./LoginForm";
 
-test("renders login form", () => {
-  render(<LoginForm onLogin={jest.fn()} onRegister={jest.fn()} />);
+test("shows validation messages for invalid submission", async () => {
+  const onLogin = jest.fn();
+  render(<LoginForm onLogin={onLogin} onRegister={jest.fn()} />);
+  await userEvent.type(screen.getByPlaceholderText(/email/i), "invalid");
+  await userEvent.type(screen.getByPlaceholderText(/password/i), "123");
+  fireEvent.click(screen.getByRole("button", { name: /login/i }));
+  expect(await screen.findByText(/invalid email format/i)).toBeInTheDocument();
+  expect(
+    await screen.findByText(/password must be at least 6 characters/i)
+  ).toBeInTheDocument();
+  expect(onLogin).not.toHaveBeenCalled();
+});
+
+test("shows success message on valid login", async () => {
+  const onLogin = jest.fn().mockResolvedValue();
+  render(<LoginForm onLogin={onLogin} onRegister={jest.fn()} />);
+  await userEvent.type(
+    screen.getByPlaceholderText(/email/i),
+    "test@example.com"
+  );
+  await userEvent.type(
+    screen.getByPlaceholderText(/password/i),
+    "123456"
+  );
+  fireEvent.click(screen.getByRole("button", { name: /login/i }));
+  expect(onLogin).toHaveBeenCalledWith("test@example.com", "123456");
+  expect(await screen.findByText(/login successful/i)).toBeInTheDocument();
+});
+
+test("shows error message on login failure", async () => {
+  const onLogin = jest
+    .fn()
+    .mockRejectedValue(new Error("Invalid credentials"));
+  render(<LoginForm onLogin={onLogin} onRegister={jest.fn()} />);
+  await userEvent.type(
+    screen.getByPlaceholderText(/email/i),
+    "test@example.com"
+  );
+  await userEvent.type(
+    screen.getByPlaceholderText(/password/i),
+    "123456"
+  );
+  fireEvent.click(screen.getByRole("button", { name: /login/i }));
+  expect(onLogin).toHaveBeenCalled();
+  expect(
+    await screen.findByText(/invalid credentials/i)
+  ).toBeInTheDocument();
 });
 

--- a/src/components/MapComponent.test.jsx
+++ b/src/components/MapComponent.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 jest.mock("react-leaflet", () => ({
   MapContainer: ({ children }) => <div>{children}</div>,
@@ -10,16 +10,46 @@ jest.mock("react-leaflet", () => ({
 
 jest.mock("../hooks/useGeolocation", () => ({
   __esModule: true,
-  default: jest.fn(() => ({
-    position: null,
-    markers: [],
-    shareLocation: jest.fn(),
-    stopSharing: jest.fn(),
-  })),
+  default: jest.fn(),
 }));
 
-test("renders map component", () => {
+const useGeolocation = require("../hooks/useGeolocation").default;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("buttons trigger shareLocation and stopSharing", () => {
+  const shareLocation = jest.fn();
+  const stopSharing = jest.fn();
+  useGeolocation.mockReturnValue({
+    position: null,
+    markers: [],
+    shareLocation,
+    stopSharing,
+  });
   const MapComponent = require("./MapComponent").default;
   render(<MapComponent currentUser={{ uid: "1" }} />);
+  fireEvent.click(screen.getByText(/share location/i));
+  fireEvent.click(screen.getByText(/stop sharing/i));
+  expect(shareLocation).toHaveBeenCalled();
+  expect(stopSharing).toHaveBeenCalled();
+});
+
+test("renders markers based on geolocation data", () => {
+  useGeolocation.mockReturnValue({
+    position: { lat: 1, lng: 2 },
+    markers: [
+      { uid: "1", lat: 1, lng: 2, email: "me@example.com" },
+      { uid: "2", lat: 3, lng: 4, email: "friend@example.com" },
+    ],
+    shareLocation: jest.fn(),
+    stopSharing: jest.fn(),
+  });
+  const MapComponent = require("./MapComponent").default;
+  render(<MapComponent currentUser={{ uid: "1" }} />);
+  expect(screen.getByText(/you are here/i)).toBeInTheDocument();
+  expect(screen.getByText(/friend@example.com/i)).toBeInTheDocument();
+  expect(screen.queryByText(/me@example.com/i)).toBeNull();
 });
 


### PR DESCRIPTION
## Summary
- Expand LoginForm tests to cover invalid input validation, successful logins, and login failures
- Extend MapComponent tests to verify share/stop location handlers and rendering of user markers

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad7d6396388328aea97ea23d5ad5ed