### PR TITLE
docs: add environment example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,26 @@
-# Copy this file to .env.local and fill in your Firebase credentials
+# Environment variables for Closeby
+# Copy this file to .env and fill in your Firebase credentials
+
+# Firebase API key
 REACT_APP_FIREBASE_API_KEY=your_api_key
+
+# Firebase Auth domain
 REACT_APP_FIREBASE_AUTH_DOMAIN=your_auth_domain
+
+# Firebase Realtime Database URL
 REACT_APP_FIREBASE_DATABASE_URL=your_database_url
+
+# Firebase project ID
 REACT_APP_FIREBASE_PROJECT_ID=your_project_id
+
+# Firebase storage bucket
 REACT_APP_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+
+# Firebase Cloud Messaging sender ID
 REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+
+# Firebase app ID
 REACT_APP_FIREBASE_APP_ID=your_app_id
+
+# Firebase measurement ID
 REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 
+## Environment Setup
+
+Copy the example environment file and update it with your Firebase credentials:
+
+```bash
+cp .env.example .env
+```
+
 ## Available Scripts
 
 In the project directory, you can run:


### PR DESCRIPTION
## Summary
- add `.env.example` with Firebase placeholders and comments
- document copying `.env.example` to `.env`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaca4afec8328abe4e3f1c770a5cb