### PR TITLE
Add ErrorBoundary component and wrap App

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // You can also log the error to an error reporting service
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert">
+          <h1>Something went wrong.</h1>
+          <p>Please check the browser console for more details.</p>
+        </div>
+      );
+    }
+
+    return this.props.children; 
+  }
+}
+
+export default ErrorBoundary;

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 import reportWebVitals from './reportWebVitals';
 import 'leaflet/dist/leaflet.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add an ErrorBoundary component with fallback UI
- wrap `<App />` in `<ErrorBoundary>` to catch runtime errors

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeacad2a3c832886308c5efca2b47f