### PR TITLE
Handle Firebase init errors with fallback warning

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,9 +2,15 @@ import React from "react";
 import useAuth from "./hooks/useAuth";
 import LoginForm from "./components/LoginForm";
 import MapComponent from "./components/MapComponent";
+import FirebaseWarning from "./components/FirebaseWarning";
+import { firebaseInitError } from "./firebase";
 
 function App() {
   const { user, login, register, logout } = useAuth();
+
+  if (firebaseInitError) {
+    return <FirebaseWarning />;
+  }
 
   return (
     <div>

--- a/src/components/FirebaseWarning.jsx
+++ b/src/components/FirebaseWarning.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function FirebaseWarning() {
+  return (
+    <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4" role="alert">
+      <p className="font-bold">Warning</p>
+      <p>Firebase initialization failed. Some features may be unavailable.</p>
+    </div>
+  );
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -16,11 +16,22 @@ const firebaseConfig = {
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+let app;
+let auth = null;
+let db = null;
+let firebaseInitError = false;
 
-// Export services
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+try {
+  // Initialize Firebase
+  app = initializeApp(firebaseConfig);
+  // Export services
+  auth = getAuth(app);
+  db = getFirestore(app);
+} catch (error) {
+  console.error("Firebase config incomplete", error);
+  firebaseInitError = true;
+}
+
+export { auth, db, firebaseInitError };
 // Optional: export const realtimeDB = getDatabase(app);
 // Optional: export const storage = getStorage(app);

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -21,11 +21,13 @@ export default function useAuth() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
+    if (!auth) return undefined;
     const unsub = onAuthStateChanged(auth, setUser);
     return () => unsub();
   }, []);
 
   const register = async (email, password) => {
+    if (!auth || !db) throw new Error("Firebase not initialized");
     const res = await createUserWithEmailAndPassword(auth, email, password);
     await setDoc(doc(db, "locations", res.user.uid), {
       uid: res.user.uid,
@@ -37,9 +39,15 @@ export default function useAuth() {
     return res.user;
   };
 
-  const login = (email, password) => signInWithEmailAndPassword(auth, email, password);
+  const login = (email, password) => {
+    if (!auth) throw new Error("Firebase not initialized");
+    return signInWithEmailAndPassword(auth, email, password);
+  };
 
-  const logout = () => signOut(auth);
+  const logout = () => {
+    if (!auth) throw new Error("Firebase not initialized");
+    return signOut(auth);
+  };
 
   return { user, register, login, logout };
 }


### PR DESCRIPTION
## Summary
- Guard Firebase initialization with try/catch, returning null services and flag on failure
- Display warning component when Firebase init fails
- Protect auth hook from running when Firebase not initialized

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden when fetching react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68aeacaba0608328a1cb33b49d4c6ea0