### PR TITLE
Add CSP meta tag to enforce external scripts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'"
+    />
+    <meta
       name="description"
       content="Web site created using create-react-app"
     />


### PR DESCRIPTION
## Summary
- add a Content Security Policy meta tag to forbid inline scripts and restrict script loading to same origin

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden when fetching react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b09db75f888328b7f6d07e15f823d2