### PR TITLE
Add Data Connect environment placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ REACT_APP_FIREBASE_APP_ID=your_app_id
 
 # Firebase measurement ID
 REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id
+
+# Data Connect API endpoint
+# Provide the base URL for your Firebase Data Connect instance.
+REACT_APP_DATA_CONNECT_URL=

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Copy the example environment file and update it with your Firebase credentials:
 cp .env.example .env
 ```
 
+Before building for deployment, be sure to populate the new `REACT_APP_DATA_CONNECT_URL`
+environment variable with the base URL of your Firebase Data Connect instance.
+
 ## Available Scripts
 
 In the project directory, you can run:


### PR DESCRIPTION
## Summary
- document the Firebase Data Connect endpoint in the environment example file and add a placeholder variable
- remind deployers in the README to fill in the new Data Connect URL before building

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce7a2c4244832cba47433c4d93cab5