### PR TITLE
Expand CSP for external map resources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'"
+      content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://{s}.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://{s}.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
     />
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- widen the Content-Security-Policy in `public/index.html` so Leaflet can load tiles, marker icons, and Firebase services during development

## Testing
- `npm start` *(blocked from completing login because the provided Firebase API key is only a placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68cea6f71550832c835f1f638af0a84e