### PR TITLE
Relax CSP for OpenStreetMap tiles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://{s}.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://{s}.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
+      content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://*.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
     />
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- allow OpenStreetMap tile subdomains by using a wildcard host in the CSP img-src and connect-src directives
- retain existing script, style, font, and Firebase allowances

## Testing
- `npm run build` *(fails: scripts/checkEnv.js reports missing Firebase environment variables in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb4b4aa20832ca8678786dffb5fa1