### PR TITLE
Align env template with Firebase config variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,28 +2,28 @@
 # Copy this file to .env and fill in your Firebase credentials
 
 # Firebase API key
-REACT_APP_FIREBASE_API_KEY=your_api_key
+REACT_APP_API_KEY=your_api_key
 
 # Firebase Auth domain
-REACT_APP_FIREBASE_AUTH_DOMAIN=your_auth_domain
+REACT_APP_AUTH_DOMAIN=your_auth_domain
 
 # Firebase Realtime Database URL
-REACT_APP_FIREBASE_DATABASE_URL=your_database_url
+REACT_APP_DATABASE_URL=your_database_url
 
 # Firebase project ID
-REACT_APP_FIREBASE_PROJECT_ID=your_project_id
+REACT_APP_PROJECT_ID=your_project_id
 
 # Firebase storage bucket
-REACT_APP_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+REACT_APP_STORAGE_BUCKET=your_storage_bucket
 
 # Firebase Cloud Messaging sender ID
-REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+REACT_APP_MESSAGING_SENDER_ID=your_messaging_sender_id
 
 # Firebase app ID
-REACT_APP_FIREBASE_APP_ID=your_app_id
+REACT_APP_APP_ID=your_app_id
 
 # Firebase measurement ID
-REACT_APP_FIREBASE_MEASUREMENT_ID=your_measurement_id
+REACT_APP_MEASUREMENT_ID=your_measurement_id
 
 # Data Connect API endpoint
 # Provide the base URL for your Firebase Data Connect instance.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,24 @@ Copy the example environment file and update it with your Firebase credentials:
 cp .env.example .env
 ```
 
-Before building for deployment, be sure to populate the new `REACT_APP_DATA_CONNECT_URL`
-environment variable with the base URL of your Firebase Data Connect instance.
+Then populate the Firebase client configuration in `.env` using the keys that the
+app reads at runtime:
+
+```
+REACT_APP_API_KEY
+REACT_APP_AUTH_DOMAIN
+REACT_APP_DATABASE_URL
+REACT_APP_PROJECT_ID
+REACT_APP_STORAGE_BUCKET
+REACT_APP_MESSAGING_SENDER_ID
+REACT_APP_APP_ID
+REACT_APP_MEASUREMENT_ID
+REACT_APP_DATA_CONNECT_URL
+```
+
+Use the same key names when configuring environment variables in your Netlify site
+settings (or any other hosting provider) so `npm run build` can find them during the
+CI build and the Firebase client receives the expected values.
 
 ## Available Scripts
 


### PR DESCRIPTION
## Summary
- rename the Firebase variables in `.env.example` to match what the client reads at runtime
- document the required environment variables and Netlify configuration guidance in the README

## Testing
- not run (environment variables are required for build scripts)


------
https://chatgpt.com/codex/tasks/task_e_68cec591853c832c9aa2429ed6144cc9