### PR TITLE
Allow inline tab script via CSP hash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://*.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
+      content="default-src 'self'; script-src 'self' https://unpkg.com 'sha256-kPx0AsF0oz2kKiZ875xSvv693TBHkQ/0SkMJZnnNpnQ='; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://*.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
     />
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- allow the inline tab.js script by adding its SHA-256 hash to the CSP script-src directive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceca011fa8832cbea1f560a3bf6560