### PR TITLE
Allow inline scripts via CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://unpkg.com 'sha256-kPx0AsF0oz2kKiZ875xSvv693TBHkQ/0SkMJZnnNpnQ='; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://*.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
+      content="default-src 'self'; script-src 'self' https://unpkg.com 'sha256-kPx0AsF0oz2kKiZ875xSvv693TBHkQ/0SkMJZnnNpnQ=' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://*.tile.openstreetmap.org https://*.googleapis.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://unpkg.com;"
     />
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- append `'unsafe-inline'` to the `script-src` directive in the CSP meta tag so injected inline code can execute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cece75e90c832c9f2c6157de461497